### PR TITLE
Switch Hackathon Consulting & MLH

### DIFF
--- a/_data/experience.yml
+++ b/_data/experience.yml
@@ -6,7 +6,7 @@
 
 - role: Director & Co-Founder
   company: Hackathon Consulting
-  dates: April 2020 – Present
+  dates: April 2020 – August 2021
   logo: assets/img/experience/hc.svg
   class: hc
 

--- a/_data/experience.yml
+++ b/_data/experience.yml
@@ -4,17 +4,17 @@
   logo: assets/img/experience/aws.png
   class: aws
 
+- role: Developer Evangelist
+  company: Major League Hacking
+  dates: February 2019 – August 2021
+  logo: assets/img/experience/mlh.svg
+  class: mlh
+
 - role: Director & Co-Founder
   company: Hackathon Consulting
   dates: April 2020 – August 2021
   logo: assets/img/experience/hc.svg
   class: hc
-
-- role: European Coach
-  company: Major League Hacking
-  dates: February 2019 – August 2021
-  logo: assets/img/experience/mlh.svg
-  class: mlh
 
 - role: Junior PHP Developer
   company: Komodo Digital


### PR DESCRIPTION
* Change `European Coach` to `Developer Evangelist` at `Major League Hacking`
* Make MLH more prominent than Hackathon Consulting