### PR TITLE
Reduce number of columns

### DIFF
--- a/_sass/all.scss
+++ b/_sass/all.scss
@@ -10,13 +10,13 @@
     grid-template-columns: repeat(4, 1fr);
 }
 
-@media only screen and (max-width: 1500px) {
+@media only screen and (max-width: 1700px) {
   .card-container {
     grid-template-columns: repeat(3, 1fr);
   }
 }
 
-@media only screen and (max-width: 1000px) {
+@media only screen and (max-width: 1200px) {
   .card-container {
     grid-template-columns: repeat(2, 1fr);
   }


### PR DESCRIPTION
Since increasing badge width from `70px` to `90px`, we need to reduce the number of columns on smaller screens (i.e. raise the window width threshold at which more columns can be shown)